### PR TITLE
server.input() and cancel() APIs

### DIFF
--- a/packages/types/types/Server.d.ts
+++ b/packages/types/types/Server.d.ts
@@ -1,4 +1,9 @@
+export type Reader = (line: string, cancel: () => void) => void;
+
 export type Server = {
 	send: (msg: string) => void;
-	read: (reader: (line: string) => void) => void;
+	/** Call cancel callback from reader to stop propagation to other readers and to Telecraft parser */
+	read: (reader: Reader) => void;
+	/** Call cancel callback from reader to stop propagation to other readers and to Minecraft server */
+	input: (reader: Reader) => void;
 };


### PR DESCRIPTION
```TypeScript
// start method of your plugin
start: async ({ server }) => {

	// new API: server.input
	server.input((line, cancel) => {

		// if this line isn't handled by our plugin, ignore it
		if (!line.startsWith("#")) return;

		// new API: cancel()
		cancel();

		// ... command will not be passed to other plugins mounted after
		// this, or Minecraft server. You should not call cancel() if
		// the command should be sent to Minecraft

		// handle command

	});

	server.read((line, cancel) => {

		// ... similar case, but read events are fired by Minecraft server
		// stdout. Calling cancel() here will stop propagating this to other
		// read listeners and also Telecraft's core Parser, preventing
		// any minecraft:* events from being triggered throughout the system

	});
}
```

Signed-off-by: Muthu Kumar <muthukumar@thefeathers.in>