### PR TITLE
Update Minecraft Wiki link to new domain after fork

### DIFF
--- a/packages/parser/src/vanilla/death.ts
+++ b/packages/parser/src/vanilla/death.ts
@@ -1,5 +1,5 @@
 /**
- * Copied from https://minecraft.fandom.com/wiki/Death_messages
+ * Copied from https://minecraft.wiki/w/Death_messages
  */
 const msgs = `
 Arrows


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom.